### PR TITLE
Use randomly generated salts

### DIFF
--- a/include/config/global.inc.dist.php
+++ b/include/config/global.inc.dist.php
@@ -23,12 +23,9 @@ $config['check_valid_coinaddress'] = true;
 
 /**
  * Defines
- *  Debug setting and salts for hashing passwords
- *   https://github.com/MPOS/php-mpos/wiki/Config-Setup#wiki-defines--salts
+ *  Debug setting
  */
 $config['DEBUG'] = 0;
-$config['SALT'] = 'PLEASEMAKEMESOMETHINGRANDOM';
-$config['SALTY'] = 'THISSHOULDALSOBERRAANNDDOOM';
 
 /**
   * Coin Algorithm


### PR DESCRIPTION
Static salts are less secure, if you get a hold of or brute-force one salt you have the salt for every account. Having random salts for each account prevents that from happening.
